### PR TITLE
Add testing support for ipfs-cluster

### DIFF
--- a/ipfs-cluster/cheats
+++ b/ipfs-cluster/cheats
@@ -1,0 +1,19 @@
+kubectl get pods -l run=ipfs-cluster -o jsonpath='{.items..metadata.name}'
+
+kubectl get pods -o jsonpath='{.items..status.podIP}'
+
+kubectl get pod -l app=ipfs-cluster-bootstrapper -o  jsonpath='{.items..status.podIP}'
+
+
+# Get boostrapper id
+kubectl exec (kubectl get pod -l app=ipfs-cluster-bootstrapper -o  jsonpath='{.items..metadata.name}') -- ipfs-cluster-ctl --enc json id | jq -r .id
+# Get bootstrapper ip
+kubectl get pod -l app=ipfs-cluster-bootstrapper -o  jsonpath='{.items..status.podIP}'
+
+# get ip from single pod
+kubectl get pods ipfs-cluster-3655037020-g83c8  -o jsonpath='{.status.podIP}'
+
+# multiaddresses from all pods
+for n in (kubectl get pods -l app=ipfs-cluster -o jsonpath='{.items[*].metadata.name}'| xargs -n1); echo "/ip4/"(kubectl get pods $n -o jsonpath='{.status.podIP}')"/tcp/9096/ipfs/"(kubectl exec $n -- ipfs-cluster-ctl --enc json id | jq -r .id); end
+
+set bootstrap (kubectl get pod -l app=ipfs-cluster-bootstrapper -o  jsonpath='{.items[].metadata.name}')

--- a/ipfs-cluster/init.sh
+++ b/ipfs-cluster/init.sh
@@ -1,0 +1,42 @@
+#! /bin/bash
+
+set -e
+
+# echo "Create Monitoring"
+# kubectl create -f ./prometheus-manifests.yml
+
+echo
+echo "Create go-ipfs deployment"
+kubectl create -f ./ipfs-cluster-deployment.yml
+
+sleep 2
+
+echo
+echo "Waiting for all containers to be running"
+
+while true; do
+    sleep 1
+    statuses=`kubectl get pods -l 'app=ipfs-cluster' -o jsonpath='{.items[*].status.phase}' | xargs -n1`
+    echo $statuses
+    all_running="yes"
+    for s in $statuses; do
+        if [[ "$s" != "Running" ]]; then
+            all_running="no"
+        fi
+    done
+    if [[ $all_running == "yes" ]]; then
+        break
+    fi
+done
+
+sleep 5
+
+echo
+echo "Adding peers to cluster"
+pods=`kubectl get pods -l 'app=ipfs-cluster,role=peer' -o jsonpath='{.items[*].metadata.name}' | xargs -n1`
+bootstrapper=`kubectl get pods -l 'app=ipfs-cluster,role=bootstrapper' -o jsonpath='{.items[*].metadata.name}'`
+
+for p in $pods; do
+    addr=$(echo "/ip4/"`kubectl get pods $p -o jsonpath='{.status.podIP}'`"/tcp/9096/ipfs/"`kubectl exec $p -- ipfs-cluster-ctl --enc json id | jq -r .id`)
+    kubectl exec $bootstrapper -- ipfs-cluster-ctl peers add "$addr"
+done

--- a/ipfs-cluster/ipfs-cluster-deployment.yml
+++ b/ipfs-cluster/ipfs-cluster-deployment.yml
@@ -1,0 +1,77 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: ipfs-cluster-bootstrapper
+  labels:
+    name: go-ipfs
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "5001"
+    prometheus.io/path: "debug/metrics/prometheus"
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: ipfs-cluster
+        role: bootstrapper
+    spec:
+      containers:
+      - name: ipfs-cluster-bootstrapper
+        image: "hsanjuan/ipfs-cluster:latest"
+        command: ["/usr/local/bin/start-daemons.sh"]
+        ports:
+        - containerPort: 4001
+          name: "swarm"
+          protocol: "TCP"
+        - containerPort: 5001
+          name: "api"
+          protocol: "TCP"
+        - containerPort: 9094
+          name: "clusterapi"
+          protocol: "TCP"
+        - containerPort: 9095
+          name: "clusterproxy"
+          protocol: "TCP"
+        - containerPort: 9096
+          name: "cluster"
+          protocol: "TCP"
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: ipfs-cluster
+  labels:
+    name: ipfs-cluster
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "5001"
+    prometheus.io/path: "debug/metrics/prometheus"
+spec:
+  replicas: 5
+  template:
+    metadata:
+      labels:
+        app: ipfs-cluster
+        role: peer
+    spec:
+      containers:
+      - name: ipfs-cluster
+        image: "hsanjuan/ipfs-cluster:latest"
+        command: ["/usr/local/bin/start-daemons.sh"]
+        ports:
+        - containerPort: 4001
+          name: "swarm"
+          protocol: "TCP"
+        - containerPort: 5001
+          name: "api"
+          protocol: "TCP"
+        - containerPort: 9094
+          name: "clusterapi"
+          protocol: "TCP"
+        - containerPort: 9095
+          name: "clusterproxy"
+          protocol: "TCP"
+        - containerPort: 9096
+          name: "cluster"
+          protocol: "TCP"

--- a/ipfs-cluster/test.sh
+++ b/ipfs-cluster/test.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+go install ..
+test $? -eq 0 || exit 1
+
+for t in tests/*.yml; do
+    kubernetes-ipfs $t
+done

--- a/ipfs-cluster/tests/pin_and_unpin.yml
+++ b/ipfs-cluster/tests/pin_and_unpin.yml
@@ -1,0 +1,31 @@
+name: Pin and unpin things in cluster
+config:
+  nodes: 5
+  selector: app=ipfs-cluster
+  times: 5
+  expected:
+      successes: 50 # 5 nodes * 5 times * 2 assertions
+      failures: 0
+      timeouts: 0
+steps:
+  - name: add random stuff to ipfs
+    on_node: 1
+    cmd: head -c 10 /dev/urandom | base64 | ipfs add -q
+    outputs:
+    - line: 0
+      save_to: HASH
+  - name: add to ipfs cluster
+    on_node: 1
+    cmd: ipfs-cluster-ctl pin add $HASH && sleep 2
+  - name: remove from ipfs cluster
+    on_node: 2
+    cmd: ipfs-cluster-ctl pin rm $HASH && sleep 1
+  - name: check that hash is unpinned everywhere
+    on_node: 1
+    end_node: 5
+    cmd: ipfs-cluster-ctl --enc json status $HASH | jq -r '.peer_map | .[].status' | sort | uniq | tee /tmp/file.txt && cat /tmp/file.txt | wc -l
+    assertions:
+      - line: 0
+        should_be_equal_to: "unpinned"
+      - line: 1
+        should_be_equal_to: "1"

--- a/ipfs-cluster/tests/pin_everywhere.yml
+++ b/ipfs-cluster/tests/pin_everywhere.yml
@@ -1,0 +1,28 @@
+name: Pin something in cluster
+config:
+  nodes: 5
+  selector: app=ipfs-cluster
+  times: 5
+  expected:
+      successes: 50 # 5 nodes * 5 times * 2 assertions
+      failures: 0
+      timeouts: 0
+steps:
+  - name: add random stuff to ipfs
+    on_node: 1
+    cmd: head -c 100 /dev/urandom | base64 | ipfs add -q
+    outputs:
+    - line: 0
+      save_to: HASH
+  - name: add to ipfs cluster
+    on_node: 1
+    cmd: ipfs-cluster-ctl pin add $HASH && sleep 2
+  - name: check that everyone has the pin
+    on_node: 1
+    end_node: 5
+    cmd: ipfs-cluster-ctl --enc json status $HASH | jq -r '.peer_map | .[].status' | sort | uniq | tee /tmp/file.txt && cat /tmp/file.txt | wc -l
+    assertions:
+      - line: 0
+        should_be_equal_to: "pinned"
+      - line: 1
+        should_be_equal_to: "1"

--- a/ipfs-cluster/tests/replication_factor.yml
+++ b/ipfs-cluster/tests/replication_factor.yml
@@ -1,0 +1,26 @@
+name: Pin with replication factor
+config:
+  nodes: 5
+  selector: app=ipfs-cluster
+  times: 10
+  expected:
+    successes: 100
+steps:
+  - name: add random stuff to ipfs
+    on_node: 1
+    cmd: head -c 100 /dev/urandom | base64 | ipfs add -q
+    outputs:
+    - line: 0
+      save_to: HASH
+  - name: add to ipfs cluster with replication factor 3
+    on_node: 1
+    cmd: ipfs-cluster-ctl pin add -r 3 $HASH && sleep 1
+  - name: check that it is only replicated in 3 nodes
+    on_node: 1
+    end_node: 5
+    cmd: ipfs-cluster-ctl --enc json status $HASH | jq -r '.peer_map | .[].status' | sort | uniq -c | sed 's/^ *//'
+    assertions:
+      - line: 0
+        should_be_equal_to: "3 pinned"
+      - line: 1
+        should_be_equal_to: "3 remote"

--- a/ipfs-cluster/tests/replication_update.yml
+++ b/ipfs-cluster/tests/replication_update.yml
@@ -1,0 +1,56 @@
+name: Change replication factor of items
+config:
+  nodes: 5
+  selector: app=ipfs-cluster
+  times: 1
+  expected:
+    successes: 22
+steps:
+  - name: add random stuff to ipfs
+    on_node: 1
+    cmd: head -c 100 /dev/urandom | base64 | ipfs add -q
+    outputs:
+    - line: 0
+      save_to: HASH
+  - name: add to ipfs cluster
+    on_node: 1
+    cmd: ipfs-cluster-ctl pin add $HASH && sleep 1
+  - name: change replication factor to 1
+    on_node: 2
+    cmd: ipfs-cluster-ctl pin add -r 1 $HASH && sleep 1
+  - name: check that it is only replicated in 1 node
+    on_node: 1
+    end_node: 5
+    cmd: ipfs-cluster-ctl --enc json status $HASH | jq -r '.peer_map | .[].status' | sort | uniq -c | sed 's/^ *//'
+    assertions:
+      - line: 0
+        should_be_equal_to: "1 pinned"
+      - line: 1
+        should_be_equal_to: "5 remote"
+  - name: change replication factor to 3
+    on_node: 2
+    cmd: ipfs-cluster-ctl pin add -r 3 $HASH && sleep 1
+  - name: check that it is only replicated in 3 node
+    on_node: 1
+    end_node: 5
+    cmd: ipfs-cluster-ctl --enc json status $HASH | jq -r '.peer_map | .[].status' | sort | uniq -c | sed 's/^ *//'
+    assertions:
+      - line: 0
+        should_be_equal_to: "3 pinned"
+      - line: 1
+        should_be_equal_to: "3 remote"
+  - name: change replication to 100000 and expect error
+    on_node: 1
+    cmd: ipfs-cluster-ctl pin add -r 1000000 $HASH 2>&1 >/dev/null | grep -o Error
+    assertions:
+      - line: 0
+        should_be_equal_to: "Error"
+  - name: change replication to -1
+    on_node: 3
+    cmd: ipfs-cluster-ctl pin add -r -1 $HASH
+  - name: check that it is pinned everywhere
+    on_node: 1
+    cmd: ipfs-cluster-ctl --enc json status $HASH | jq -r '.peer_map | .[].status' | sort | uniq -c | sed 's/^ *//'
+    assertions:
+      - line: 0
+        should_be_equal_to: "6 pinned"

--- a/ipfs-cluster/tests/start_and_check.yml
+++ b/ipfs-cluster/tests/start_and_check.yml
@@ -1,0 +1,24 @@
+name: Check that all cluster peers know each others
+config:
+  nodes: 5
+  selector: app=ipfs-cluster
+  times: 1
+  expected:
+      successes: 5
+      failures: 0
+      timeouts: 0
+steps:
+  - name: list nodes
+    on_node: 1
+    cmd: ipfs-cluster-ctl --enc json peers ls | jq -r '.[].id' | sort | tr '\n' ' '
+    timeout: 0
+    outputs:
+    - line: 0
+      save_to: PIDS
+  - name: Check that nodes match
+    on_node: 1
+    end_node: 5
+    cmd: ipfs-cluster-ctl --enc json peers ls | jq -r '.[].id' | sort | tr '\n' ' '
+    assertions:
+    - line: 0
+      should_be_equal_to: PIDS

--- a/ipfs-cluster/tests/sync_and_recover.yml
+++ b/ipfs-cluster/tests/sync_and_recover.yml
@@ -1,0 +1,42 @@
+name: Pin something in cluster
+config:
+  nodes: 5
+  selector: app=ipfs-cluster
+  times: 2
+  expected:
+      successes: 8
+      failures: 0
+      timeouts: 0
+steps:
+  - name: add random stuff to ipfs
+    on_node: 1
+    cmd: head -c 100 /dev/urandom | base64 | ipfs add -q
+    outputs:
+    - line: 0
+      save_to: HASH
+  - name: add to ipfs cluster
+    on_node: 1
+    cmd: ipfs-cluster-ctl pin add $HASH && sleep 2
+  - name: unpin under the hood
+    on_node: 1
+    cmd: ipfs pin rm $HASH
+  - name: running sync identifies the problem
+    on_node: 1
+    cmd: ipfs-cluster-ctl --enc json sync $HASH | jq -r '.peer_map | .[].status' | sort | uniq -c | sed 's/^ *//'
+    assertions:
+      - line: 0
+        should_be_equal_to: "1 pin_error"
+      - line: 1
+        should_be_equal_to: "5 pinned"
+  - name: running recover fixes the problem
+    on_node: 1
+    cmd: ipfs-cluster-ctl --enc json recover $HASH | jq -r '.cid' && sleep 2
+    assertions:
+      - line: 0
+        should_be_equal_to: HASH
+  - name: check that the problem has been fixed
+    on_node: 1
+    cmd: ipfs-cluster-ctl --enc json status $HASH | jq -r '.peer_map | .[].status' | sort | uniq -c | sed 's/^ *//'
+    assertions:
+      - line: 0
+        should_be_equal_to: "6 pinned"

--- a/tests/add-and-gc.yml
+++ b/tests/add-and-gc.yml
@@ -1,5 +1,6 @@
 name: Add and GC
 config:
+  selector: run=go-ipfs-stress
   nodes: 1
   times: 10
   expected:

--- a/tests/cross-connectivity.yml
+++ b/tests/cross-connectivity.yml
@@ -1,5 +1,6 @@
 name: Cross-Network Connectivity
 config:
+  selector: run=go-ipfs-stress
   nodes: 3
   times: 3
   expected:

--- a/tests/failing-not-present.yml
+++ b/tests/failing-not-present.yml
@@ -1,5 +1,6 @@
 name: Failing - Not Present
 config:
+  selector: run=go-ipfs-stress
   nodes: 2
   times: 10
   expected:

--- a/tests/failing-simple-add-and-cat.yml
+++ b/tests/failing-simple-add-and-cat.yml
@@ -1,6 +1,7 @@
 name: Failing Simple Add and Cat
 config:
   nodes: 2
+  selector: run=go-ipfs-stress
   times: 10
   expected:
       successes: 0

--- a/tests/moving-medium.yml
+++ b/tests/moving-medium.yml
@@ -1,6 +1,7 @@
 name: Moving a medium-sized file across the internet
 config:
   nodes: 4
+  selector: run=go-ipfs-stress
   times: 3
   expected:
       successes: 6

--- a/tests/simple-add-and-cat.yml
+++ b/tests/simple-add-and-cat.yml
@@ -1,6 +1,7 @@
 name: Simple Add and Cat on 2 Node
 config:
   nodes: 2
+  selector: run=go-ipfs-stress
   times: 10
   expected:
       successes: 10

--- a/tests/simple-add-and-pin.yml
+++ b/tests/simple-add-and-pin.yml
@@ -1,6 +1,7 @@
 name: Simple Add and Pin
 config:
   nodes: 5
+  selector: run=go-ipfs-stress
   times: 25
   grace_shutdown: 10
   expected:

--- a/tests/swarm.yml
+++ b/tests/swarm.yml
@@ -1,6 +1,7 @@
 name: Swarm downloading a small file
 config:
   nodes: 11
+  selector: run=go-ipfs-stress
   times: 3
   expected:
       successes: 30

--- a/tests/transitive.yml
+++ b/tests/transitive.yml
@@ -1,6 +1,7 @@
 name: Transitive
 config:
   nodes: 3
+  selector: run=go-ipfs-stress
   times: 10
   expected:
       successes: 10


### PR DESCRIPTION
This is the minimal necessary to allow me to write and run some tests for cluster

  * Add ipfs-cluster setup scripts and a test
  * Features and fixes to kubernetes-ipfs
     * Support custom selector (rather than hardcode go-ipfs-stress)
     * Fix panics when outputs does not have as many lines as expected
     * Fix env being provided unquoted and thus injecting bash commands
     * Fix env matching with ShouldBeEqual where match could happen if the variable name is just part of the output

I have run some of the original ipfs tests and they look good (meaning I haven't broken stuff with the changes).
