### PR TITLE
Fix OnNode - EndNode bug

### DIFF
--- a/main.go
+++ b/main.go
@@ -186,7 +186,7 @@ func handleStep(pods GetPodsOutput, step *Step, summary *Summary, env []string) 
 	outputErr := make(chan bool, numNodes)
 	for j := step.OnNode; j <= endNode; j++ {
 		// Hand this channel to the pod runner and let it fill the queue
-		runInPodAsync(pods.Items[step.OnNode-1].Metadata.Name, step.CMD, env, step.Timeout, outputStrings, outputErr)
+		runInPodAsync(pods.Items[j-1].Metadata.Name, step.CMD, env, step.Timeout, outputStrings, outputErr)
 	}
 	// Iterate through the queue to pull out results one-by-one
 	// These may be out of order, but is there a better way to do this? Do we need them in order?


### PR DESCRIPTION
Line 189 looks like it issues the command to run on 1 node n times, when it should be issuing the command to run 1 time on the n nodes in the range between OnNode and EndNode.  