### PR TITLE
Feat/parameters

### DIFF
--- a/ipfs-cluster/ipfs-cluster-deployment.yml
+++ b/ipfs-cluster/ipfs-cluster-deployment.yml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
       - name: ipfs-cluster-bootstrapper
-        image: "ipfs/ipfs-cluster:latest"
+        image: "hsanjuan/ipfs-cluster:latest"
         command: ["/usr/local/bin/start-daemons.sh"]
         ports:
         - containerPort: 4001
@@ -57,7 +57,7 @@ spec:
     spec:
       containers:
       - name: ipfs-cluster
-        image: "ipfs/ipfs-cluster:latest"
+        image: "hsanjuan/ipfs-cluster:latest"
         command: ["/usr/local/bin/start-daemons.sh"]
         ports:
         - containerPort: 4001

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"flag"
 	"fmt"
 	"io/ioutil"
 	"math/rand"
@@ -222,20 +223,82 @@ func fatal(i interface{}) {
 	os.Exit(1)
 }
 
-func init() {
-	rand.Seed(time.Now().UTC().UnixNano())
+// Opts holds the result of parsed input args
+type Opts struct {
+	params Params
+}
+
+// all input options + corresponding data structures should be defined here
+func newOpts() *Opts {
+	opts := &Opts{
+		params: make(Params),
+	}
+
+	flag.Var(&opts.params, "param",
+		`Replace all test parameter instances of <name> with <value>.
+        Separate multiple `+"`<name>:<value>` inputs with ',' or pass this flag multiple times.")
+
+	return opts
+}
+
+/* parse all input args */
+func parseArgs() (*Opts, []string) {
+	// create opts
+	opts := newOpts()
+	// set usage
+	flag.Usage = usage
+	// parse all args
+	flag.Parse()
+
+	// get all non-flag args
+	rest := append([]string{os.Args[0]}, flag.Args()...)
+
+	return opts, rest
+}
+
+// Params holds the parameter mappings specified  by user
+type Params map[PName]PValue
+type PName string
+type PValue string
+
+// specific Params -> String transformation
+func (params *Params) String() string {
+	return fmt.Sprint(*params)
+}
+
+// tell `flag` package how to parse/store param args
+func (params *Params) Set(value string) error {
+	for _, p := range strings.Split(value, ",") {
+		pElems := strings.SplitN(p, ":", 2)
+		if len(pElems) != 2 {
+			return fmt.Errorf("Bad parameter declaration: %s %d", p)
+		}
+		pName := PName(pElems[0])
+		pValue := PValue(pElems[1])
+		(*params)[pName] = pValue
+	}
+	return nil
+}
+
+func usage() {
+	fmt.Fprintf(os.Stderr, "USAGE\n")
+	fmt.Fprintf(os.Stderr, "  kubernetes-ipfs [--param=<name>:<value>,...] <testfile>\n\n")
+	fmt.Fprintf(os.Stderr, "OPTIONS\n")
+	flag.PrintDefaults()
+	fmt.Fprintf(os.Stderr,
+		`  -help
+        Show this help message and exit`)
+	fmt.Fprintf(os.Stderr, "\n")
 }
 
 func main() {
-	args := os.Args
-	if len(args) < 2 {
-		fmt.Println("Usage: ", args[0], "<testfile>")
-		os.Exit(1)
-	}
+	// opts = parsed option results, args = all other non-flag input args
+	opts, args := parseArgs()
 
-	var params = make(map[string]string)
-	if len(args) > 2 {
-		params = parseArgs(args[2:])
+	if len(args) != 2 {
+		// no test file in input, print usage and exit
+		usage()
+		os.Exit(1)
 	}
 
 	filePath := args[1]
@@ -246,7 +309,7 @@ func main() {
 		fatal(err)
 	}
 
-	fileData = replaceAllParams(fileData, params)
+	fileData = replaceAllParams(fileData, opts.params)
 
 	var test Test
 	var summary Summary
@@ -344,24 +407,8 @@ func PrintResults(summary Summary, test Test) {
 	os.Exit(evaluateOutcome(summary, test.Config.Expected)) // Returns success on all tests to OS; this allows for test scripting.
 }
 
-/* parse all input args of the form `parameter=value`, e.g. `X=5` */
-func parseArgs(args []string) map[string]string {
-	parsedArgs := make(map[string]string)
-	for _, arg := range args {
-		splitArgs := strings.Split(arg, "=")
-		if len(splitArgs) != 2 {
-			fmt.Println("Bad assignment: " + arg)
-			os.Exit(1)
-		}
-
-		param, val := splitArgs[0], splitArgs[1]
-		parsedArgs[param] = val
-	}
-	return parsedArgs
-}
-
 /* resolve all parameters in test file */
-func replaceAllParams(fileData []byte, params map[string]string) []byte {
+func replaceAllParams(fileData []byte, params Params) []byte {
 	// replace all given parameters with their specified values
 	fileData = replaceInputParams(fileData, params)
 	// replace all other parameters with their default values
@@ -370,14 +417,8 @@ func replaceAllParams(fileData []byte, params map[string]string) []byte {
 	return fileData
 }
 
-func compileParamRegex(param string) *regexp.Regexp {
-	// matches strings of the form `%{parameter}` and `%{parameter, value}`
-	paramRegex, _ := regexp.Compile("%\\{\\s*" + param + "\\s*(?:,\\s*.*?\\s*)?\\}")
-	return paramRegex
-}
-
 /* resolve all param names (keys in `params` map) to their resp. values */
-func replaceInputParams(fileData []byte, params map[string]string) []byte {
+func replaceInputParams(fileData []byte, params Params) []byte {
 	for param, val := range params {
 		paramRegex := compileParamRegex(param)
 		fileData = paramRegex.ReplaceAll(fileData, []byte(val))
@@ -392,11 +433,17 @@ func replaceDefaultParams(fileData []byte) []byte {
 
 	/* replace all occurrences of `%{parameter, value}` with `value` */
 	for _, defaultParam := range defaultParams {
-		param, val := string(defaultParam[1]), defaultParam[2]
+		param, val := PName(defaultParam[1]), defaultParam[2]
 		paramRegex := compileParamRegex(param)
 		fileData = paramRegex.ReplaceAll(fileData, []byte(val))
 	}
 	return fileData
+}
+
+func compileParamRegex(param PName) *regexp.Regexp {
+	// matches strings of the form `%{parameter}` and `%{parameter, value}`
+	paramRegex, _ := regexp.Compile("%\\{\\s*" + string(param) + "\\s*(?:,\\s*.*?\\s*)?\\}")
+	return paramRegex
 }
 
 func handleStep(pods GetPodsOutput, step *Step, summary *Summary, env []string) []string {

--- a/main_test.go
+++ b/main_test.go
@@ -20,7 +20,7 @@ func visitBad(path string, f os.FileInfo, pathErr error) error {
 	if f.IsDir() {
 		return nil /* skip dir, not a test file */
 	}
-	test, err := readTestFile(path)
+	test, err := loadTest(path, newTestConfig())
 	if err != nil {
 		return err
 	}
@@ -51,7 +51,7 @@ func visit(path string, f os.FileInfo, pathErr error) error {
 	if f.IsDir() {
 		return nil /* skip dir, not a test file */
 	}
-	test, err := readTestFile(path)
+	test, err := loadTest(path, newTestConfig())
 	if err != nil {
 		return err
 	}

--- a/params.go
+++ b/params.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// Params holds the parameter mappings specified  by user
+type Params map[string]string
+
+var pNamePattern = `([A-Za-z_][0-9A-Za-z_]*)`
+
+var pNameRegex = regexp.MustCompile(`^` + pNamePattern + `$`)
+var paramDecRegex = regexp.MustCompile(`{{ *` + pNamePattern + ` *}}`)
+var paramRegex = regexp.MustCompile(pNamePattern + `=(.+?)`)
+
+// specific Params -> String transformation
+func (params *Params) String() string {
+	return fmt.Sprint(*params)
+}
+
+// tell `flag` package how to parse/store param args
+func (params *Params) Set(input string) error {
+	// for each `--param` flag...
+	for _, p := range strings.Split(input, ",") {
+		// split params on ,
+		pElems := strings.SplitN(p, "=", 2)
+		// check number of elements in param arg
+		switch len(pElems) {
+		case 0:
+			return fmt.Errorf("Missing argument to `--param` flag.")
+		case 1:
+			return fmt.Errorf("Missing value in parameter arg: %s", p)
+		}
+		// validate string as PName identifer
+		pName, pValue := pElems[0], pElems[1]
+
+		(*params)[pName] = pValue
+	}
+	return nil
+}
+
+/* resolve all param names (keys in `params` map) to their resp. values */
+func replaceParams(fileData []byte, params Params) ([]byte, error) {
+	// get all unique param declarations from test file
+	matches := uniqueParamDeclarations(fileData)
+	for pDeclaration, pName := range matches {
+		// check whether the reference parameter is defined
+		if pVal, ok := params[pName]; ok {
+			// parameter found, replace all occurrences with its value
+			fileData = bytes.Replace(fileData, []byte(pDeclaration), []byte(pVal), -1)
+		} else {
+			// parameter not found, fail
+			return []byte{}, fmt.Errorf("Parameter %s not specified", pName)
+		}
+	}
+	return fileData, nil
+}
+
+/* returns all unique parameter declarations in a test file */
+func uniqueParamDeclarations(fileData []byte) map[string]string {
+	// get all regex results
+	regexResults := paramDecRegex.FindAllSubmatch(fileData, -1)
+	// matchSet is map from '{{ <varName> }}' to '<varName>'
+	matchSet := make(map[string]string)
+	for _, result := range regexResults {
+		matchSet[string(result[0])] = string(result[1])
+	}
+	return matchSet
+}

--- a/params_test.go
+++ b/params_test.go
@@ -1,0 +1,148 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"testing"
+)
+
+// test that various replacements succeed
+func TestReplacement(t *testing.T) {
+	template, err := ioutil.ReadFile("tests/add-and-gc-template.yml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	target, err := ioutil.ReadFile("tests/add-and-gc.yml")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	params := Params{"NUM_NODES": "1",
+		"NUM_TIMES": "10",
+		"FILE_SIZE": "10",
+		"ON_NODE":   "1",
+	}
+
+	processedTemplate, err := replaceParams(template, params)
+
+	if err != nil {
+		t.Log(err)
+	}
+
+	if bytes.Compare(processedTemplate, target) != 0 {
+		t.Fatal("Template with replaced params not equal to target test.")
+	}
+}
+
+// test that bad replacement fails
+func TestBadReplacement(t *testing.T) {
+	template, err := ioutil.ReadFile("tests/add-and-gc-template.yml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	target, err := ioutil.ReadFile("tests/add-and-gc.yml")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	params := Params{"NUM_NODES": "1",
+		"NUM_TIMES": "10",
+		"FILE_SIZE": "10",
+		"ON_NODE":   "0",
+	}
+
+	processedTemplate, err := replaceParams(template, params)
+
+	if err != nil {
+		t.Log(err)
+	}
+
+	if bytes.Compare(processedTemplate, target) == 0 {
+		t.Fatal("This test should have failed (wrong replacement value).")
+	}
+}
+
+// test that replacement using config file succeeds
+func TestConfigReplacement(t *testing.T) {
+	template, err := ioutil.ReadFile("tests/add-and-gc-template.yml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	target, err := ioutil.ReadFile("tests/add-and-gc.yml")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	config, err := loadConfigFile("testutils/add-and-gc-config.yml")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	processedTemplate, err := replaceParams(template, config.Params)
+
+	if err != nil {
+		t.Log(err)
+	}
+
+	if bytes.Compare(processedTemplate, target) != 0 {
+		t.Fatal("Template with replaced params not equal to target test.")
+	}
+}
+
+// test that parameter addition works as expected
+func TestParamsOverride(t *testing.T) {
+	template, err := ioutil.ReadFile("tests/add-and-gc-template.yml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	target, err := ioutil.ReadFile("tests/add-and-gc.yml")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	params1 := Params{"NUM_NODES": "1",
+		"NUM_TIMES": "10",
+		"ON_NODE":   "0",
+	}
+	params2 := Params{"NUM_NODES": "1",
+		"FILE_SIZE": "10",
+		"ON_NODE":   "1",
+	}
+
+	config := TestConfig{Params: make(Params)}
+	config.addParams(params1)
+	config.addParams(params2)
+
+	processedTemplate, err := replaceParams(template, config.Params)
+
+	if err != nil {
+		t.Log(err)
+	}
+
+	if bytes.Compare(processedTemplate, target) != 0 {
+		t.Fatal("Template with replaced params not equal to target test.")
+	}
+}
+
+// test that missing parameters fail replacement
+func TestUndeclaredParams(t *testing.T) {
+	template, err := ioutil.ReadFile("tests/add-and-gc-template.yml")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	params := Params{"NUM_NODES": "1",
+		"NUM_TIMES": "10",
+		"FILE_SIZE": "10",
+	}
+
+	_, err = replaceParams(template, params)
+
+	if err == nil {
+		t.Fatal("Param replacement should have failed (missing value).")
+	}
+	if err.Error() != fmt.Sprintf("Parameter ON_NODE not specified") {
+		t.Fatal(fmt.Sprintf("Failed with different error than intended: %s", err))
+	}
+}

--- a/tests/add-and-gc-template.yml
+++ b/tests/add-and-gc-template.yml
@@ -1,0 +1,30 @@
+name: Add and GC
+config:
+  selector: run=go-ipfs-stress
+  nodes: {{ NUM_NODES }}
+  times: {{ NUM_TIMES }}
+  expected:
+      successes: {{ NUM_TIMES }}
+      failures: 0
+      timeouts: 0
+steps:
+  - name: Add file
+    on_node: {{ON_NODE }}
+    cmd: head -c {{FILE_SIZE}} /dev/urandom | base64 > /tmp/file.txt && cat /tmp/file.txt && ipfs add -q /tmp/file.txt
+    outputs: 
+    - line: 0
+      save_to: FILE
+    - line: 1
+      save_to: HASH
+  - name: Cat added file
+    on_node: {{    ON_NODE}}
+    inputs:
+      - FILE
+      - HASH
+    cmd: ipfs cat $HASH
+    assertions:
+    - line: 0
+      should_be_equal_to: FILE
+  - name: Run GC
+    on_node: 1
+    cmd: ipfs repo gc

--- a/testutils/add-and-gc-config.yml
+++ b/testutils/add-and-gc-config.yml
@@ -1,0 +1,5 @@
+params:
+    NUM_NODES: 1
+    NUM_TIMES: 10
+    FILE_SIZE: 10
+    ON_NODE:   1


### PR DESCRIPTION
Added a feature for inputting parameters to tests, see the commit message for more details. This will make it easier to run tests over various parameters (number of nodes, file size, etc.), and works nicely with the `write_to_file` feature for saving output to files whose names reflect the parameters they were ran with.

**Commit message (note: this is now out-of-date, see actual commit message)**:

Added a feature that allows tests to be parameterized over specified variables,
whose concrete values may be assigned via command line arguments at runtime.
Parameters may be specified in tests by `%{P}`, where `P` is the parameter
identifer (which can be any string without whitespace), or by `%{P, V}`, where
`V` is the default value for `P`.

Example: running a test with `go run main.go i=1` replaces all occurrences of
`%{i}` *and* `%{i, <default_value>}` with `1`. If the same test is instead run
without the `i=1` argument (i.e. `go run main.go`), then the program will find
`i`'s default value by searching the test for a string of the form
`%{i, <default_value>}`. It will then replace all `%{i}` *and* `%{i, <v>}`
instances with `<default_value>`.

The `<default_value>` for a parameter should only be specified once. So, if
`i`'s default value is `0`, then the first time `i` is used should look like
`%{i, 0}`, then all following references to `i` should just use `%{i}`.