### PR TITLE
deployment now points at link to stable test image

### DIFF
--- a/ipfs-cluster/ipfs-cluster-deployment.yml
+++ b/ipfs-cluster/ipfs-cluster-deployment.yml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
       - name: ipfs-cluster-bootstrapper
-        image: "hsanjuan/ipfs-cluster:latest"
+        image: "ipfs/ipfs-cluster-test:latest"
         command: ["/usr/local/bin/start-daemons.sh"]
         ports:
         - containerPort: 4001
@@ -57,7 +57,7 @@ spec:
     spec:
       containers:
       - name: ipfs-cluster
-        image: "hsanjuan/ipfs-cluster:latest"
+        image: "ipfs/ipfs-cluster-test:latest"
         command: ["/usr/local/bin/start-daemons.sh"]
         ports:
         - containerPort: 4001


### PR DESCRIPTION
We just added this dockerhub link today!  We will try to keep this link up to date with the build of the ipfs cluster test image from within the published master branch of the ipfs-cluster repo, and at the very least this will be updated during each ipfs-cluster release.