### PR TITLE
feat: add kubernetes terraform

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,41 @@
+# kubernetes terraform
+
+based on https://github.com/hobby-kube/guide
+
+## Config
+
+```bash
+export AWS_ACCESS_KEY_ID=""
+export AWS_SECRET_ACCESS_KEY=""
+
+# For DigitalOcean, use either
+export DIGITALOCEAN_TOKEN=""
+# or
+export TF_VAR_digitalocean_token=""
+```
+
+In `terraform.auto.tfvars`:
+
+- update `backend "s3"` block to use a unique S3 bucket name
+- update `domain` key's value to a domain that is set as a hosted zone in AWS Route53 to resolve DNS
+- add GitHub usernames to `ssh_authorized_keys_github`. These keys will be deployed to the cluster members under the `root` user
+- add the DigitalOcean SSH keys to write to the hosts
+  - this is used to provision kubernetes on the nodes
+  - this key should be available to terraform, e.g. in an `ssh-agent`
+- region and instance sizes can be modified
+
+
+Terraform state is stored in S3 with DynamoDB locking.
+
+### Usage
+
+```sh
+# fetch the required modules
+$ terraform init hobby-kube/
+
+# see what `terraform apply` will do
+$ terraform plan hobby-kube/
+
+# execute it
+$ terraform apply hobby-kube/
+```

--- a/terraform/hobby-kube/.gitignore
+++ b/terraform/hobby-kube/.gitignore
@@ -1,0 +1,4 @@
+.terraform/
+terraform.tfstate*
+.terraform.tfstate*
+terraform.tfvars

--- a/terraform/hobby-kube/LICENSE
+++ b/terraform/hobby-kube/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2017 by Patrick Stadler
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/terraform/hobby-kube/README.md
+++ b/terraform/hobby-kube/README.md
@@ -1,0 +1,98 @@
+# Kubernetes cluster setup automation
+
+> This is part of the Hobby Kube project. Functionality of the modules is described in the [guide](https://github.com/hobby-kube/guide).
+
+Deploy a secure Kubernetes cluster on [Hetzner Cloud](https://www.hetzner.com/cloud), [Scaleway](https://www.scaleway.com/) or [DigitalOcean](https://www.digitalocean.com/) using [Terraform](https://www.terraform.io/).
+
+## Setup
+
+### Requirements
+
+The following packages are required to be installed locally:
+
+```sh
+brew install terraform kubectl jq wireguard-tools
+```
+
+Modules are using ssh-agent for remote operations. Add your SSH key with `ssh-add -K` if Terraform repeatedly fails to connect to remote hosts.
+
+### Configuration
+
+Export the following environment variables depending on the modules you're using.
+
+#### Using Hetzner Cloud as provider
+
+At the time of writing the Hetzner Cloud provider requires manual installation.
+Follow the instructions here: [hetznercloud/terraform-provider-hcloud](https://github.com/hetznercloud/terraform-provider-hcloud/blob/master/README.md#installing-the-provider).
+
+```sh
+export TF_VAR_hcloud_token=<token>
+export TF_VAR_hcloud_ssh_keys=<keys> # e.g. '["12548","17593"]'
+```
+
+#### Using Scaleway as provider
+
+```sh
+export TF_VAR_scaleway_organization=<access_key>
+export TF_VAR_scaleway_token=<token>
+```
+
+#### Using DigitalOcean as provider
+
+```sh
+export TF_VAR_digitalocean_token=<token>
+export TF_VAR_digitalocean_ssh_keys=<keys> # e.g. '["121671", "1714133"]'
+```
+
+#### Using Cloudflare for DNS entries
+
+```sh
+export TF_VAR_domain=<domain> # e.g. example.org
+export TF_VAR_cloudflare_email=<email>
+export TF_VAR_cloudflare_token=<token>
+```
+
+#### Using Amazon Route 53 for DNS entries
+
+```sh
+export TF_VAR_domain=<domain> # e.g. example.org shall be already added to hosted zones.
+export TF_VAR_aws_access_key=<ACCESS_KEY>
+export TF_VAR_aws_secret_key=<SECRET_KEY>
+export TF_VAR_aws_region=<region> # e.g. eu-west-1
+```
+
+#### Install additional APT packages
+
+Each provider takes an optional variable to install further packages during provisioning:
+
+```
+module "provider" {
+  # ...
+  apt_packages = ["ceph-common", "nfs-common"]
+}
+```
+
+### Usage
+
+```sh
+# fetch the required modules
+$ terraform init
+
+# see what `terraform apply` will do
+$ terraform plan
+
+# execute it
+$ terraform apply
+```
+
+## Using modules independently
+
+Modules in this repository can be used independently:
+
+```
+module "kubernetes" {
+  source  = "github.com/hobby-kube/provisioning/service/kubernetes"
+}
+```
+
+After adding this to your plan, run `terraform get` to fetch the module.

--- a/terraform/hobby-kube/dns/aws/main.tf
+++ b/terraform/hobby-kube/dns/aws/main.tf
@@ -1,0 +1,61 @@
+variable "count" {}
+
+variable "access_key" {}
+
+variable "secret_key" {}
+
+variable "region" {}
+
+variable "domain" {}
+
+variable "hostnames" {
+  type = "list"
+}
+
+variable "public_ips" {
+  type = "list"
+}
+
+# Configure the AWS Provider
+provider "aws" {
+  access_key = "${var.access_key}"
+  secret_key = "${var.secret_key}"
+  region     = "${var.region}"
+}
+
+data "aws_route53_zone" "selected_domain" {
+  name = "${var.domain}."
+}
+
+resource "aws_route53_record" "hosts" {
+  count = "${var.count}"
+
+  zone_id = "${data.aws_route53_zone.selected_domain.zone_id}"
+  name    = "${element(var.hostnames, count.index)}.${data.aws_route53_zone.selected_domain.name}"
+  type    = "A"
+  ttl     = "300"
+  records = ["${element(var.public_ips, count.index)}"]
+}
+
+resource "aws_route53_record" "domain" {
+  zone_id = "${data.aws_route53_zone.selected_domain.zone_id}"
+
+  name    = "${data.aws_route53_zone.selected_domain.name}"
+  type    = "A"
+  ttl     = "300"
+  records = ["${element(var.public_ips, 0)}"]
+}
+
+resource "aws_route53_record" "wildcard" {
+  depends_on = ["aws_route53_record.domain"]
+
+  zone_id = "${data.aws_route53_zone.selected_domain.zone_id}"
+  name    = "*"
+  type    = "CNAME"
+  ttl     = "300"
+  records = ["${data.aws_route53_zone.selected_domain.name}"]
+}
+
+output "domains" {
+  value = ["${aws_route53_record.hosts.*.name}"]
+}

--- a/terraform/hobby-kube/dns/cloudflare/main.tf
+++ b/terraform/hobby-kube/dns/cloudflare/main.tf
@@ -1,0 +1,52 @@
+variable "count" {}
+
+variable "email" {}
+
+variable "token" {}
+
+variable "domain" {}
+
+variable "hostnames" {
+  type = "list"
+}
+
+variable "public_ips" {
+  type = "list"
+}
+
+provider "cloudflare" {
+  email = "${var.email}"
+  token = "${var.token}"
+}
+
+resource "cloudflare_record" "hosts" {
+  count = "${var.count}"
+
+  domain  = "${var.domain}"
+  name    = "${element(var.hostnames, count.index)}"
+  value   = "${element(var.public_ips, count.index)}"
+  type    = "A"
+  proxied = false
+}
+
+resource "cloudflare_record" "domain" {
+  domain  = "${var.domain}"
+  name    = "${var.domain}"
+  value   = "${element(var.public_ips, 0)}"
+  type    = "A"
+  proxied = true
+}
+
+resource "cloudflare_record" "wildcard" {
+  depends_on = ["cloudflare_record.domain"]
+
+  domain  = "${var.domain}"
+  name    = "*"
+  value   = "${var.domain}"
+  type    = "CNAME"
+  proxied = false
+}
+
+output "domains" {
+  value = ["${cloudflare_record.hosts.*.hostname}"]
+}

--- a/terraform/hobby-kube/dns/google/main.tf
+++ b/terraform/hobby-kube/dns/google/main.tf
@@ -1,0 +1,57 @@
+variable "count" {}
+
+variable "project" {}
+
+variable "region" {}
+
+variable "creds_file" {}
+
+variable "managed_zone" {}
+
+variable "domain" {}
+
+variable "hostnames" {
+  type = "list"
+}
+
+variable "public_ips" {
+  type = "list"
+}
+
+provider "google" {
+  credentials = "${file(var.creds_file)}"
+  project     = "${var.project}"
+  region      = "${var.region}"
+}
+
+resource "google_dns_record_set" "hosts" {
+  count = "${var.count}"
+
+  name         = "${element(var.hostnames, count.index)}.${var.domain}."
+  type         = "A"
+  ttl          = 300
+  managed_zone = "${var.managed_zone}"
+  rrdatas      = ["${element(var.public_ips, count.index)}"]
+}
+
+resource "google_dns_record_set" "domain" {
+  name         = "${var.domain}."
+  type         = "A"
+  ttl          = 300
+  managed_zone = "${var.managed_zone}"
+  rrdatas      = ["${element(var.public_ips, 0)}"]
+}
+
+resource "google_dns_record_set" "wildcard" {
+  depends_on = ["google_dns_record_set.domain"]
+
+  name         = "*.${var.domain}."
+  type         = "CNAME"
+  ttl          = 300
+  managed_zone = "${var.managed_zone}"
+  rrdatas      = ["${var.domain}."]
+}
+
+output "domains" {
+  value = ["${google_dns_record_set.hosts.*.name}"]
+}

--- a/terraform/hobby-kube/main.tf
+++ b/terraform/hobby-kube/main.tf
@@ -1,0 +1,147 @@
+module "provider" {
+  source          = "./provider/digitalocean"
+
+  token           = "${var.digitalocean_token}"
+  ssh_keys        = "${var.digitalocean_ssh_keys}"
+  size            = "${var.digitalocean_size}"
+  hosts           = "${var.hosts}"
+  hostname_format = "${var.hostname_format}"
+  region          = "${var.digitalocean_region}"
+}
+
+module "dns" {
+  source     = "./dns/aws"
+
+  count      = "${var.hosts}"
+  access_key = "${var.aws_access_key}"
+  secret_key = "${var.aws_secret_key}"
+  region     = "${var.aws_region}"
+  domain     = "${var.domain}"
+  public_ips = "${module.provider.public_ips}"
+  hostnames  = "${module.provider.hostnames}"
+}
+
+module "swap" {
+  source      = "./service/swap"
+
+  count       = "${var.hosts}"
+  connections = "${module.provider.public_ips}"
+}
+
+module "wireguard" {
+  source       = "./security/wireguard"
+
+  count        = "${var.hosts}"
+  connections  = "${module.provider.public_ips}"
+  private_ips  = "${module.provider.private_ips}"
+  hostnames    = "${module.provider.hostnames}"
+  overlay_cidr = "${module.kubernetes.overlay_cidr}"
+}
+
+module "firewall" {
+  source               = "./security/ufw"
+
+  count                = "${var.hosts}"
+  connections          = "${module.provider.public_ips}"
+  private_interface    = "${module.provider.private_network_interface}"
+  vpn_interface        = "${module.wireguard.vpn_interface}"
+  vpn_port             = "${module.wireguard.vpn_port}"
+  kubernetes_interface = "${module.kubernetes.overlay_interface}"
+}
+
+module "etcd" {
+  source      = "./service/etcd"
+
+  count       = "${var.hosts}"
+  connections = "${module.provider.public_ips}"
+  hostnames   = "${module.provider.hostnames}"
+  vpn_unit    = "${module.wireguard.vpn_unit}"
+  vpn_ips     = "${module.wireguard.vpn_ips}"
+}
+
+module "kubernetes" {
+  source                     = "./service/kubernetes"
+
+  count                      = "${var.hosts}"
+  connections                = "${module.provider.public_ips}"
+  cluster_name               = "${var.domain}"
+  vpn_interface              = "${module.wireguard.vpn_interface}"
+  vpn_ips                    = "${module.wireguard.vpn_ips}"
+  etcd_endpoints             = "${module.etcd.endpoints}"
+  ssh_authorized_keys_github = "${var.ssh_authorized_keys_github}"
+}
+
+output "kube_overlay_cidr" {
+  value = "${module.kubernetes.overlay_cidr}"
+}
+output "kube_overlay_interface" {
+  value = "${module.kubernetes.overlay_interface}"
+}
+
+output "master_ip" {
+  value = "${module.provider.public_ips[0]}"
+}
+
+output "master_hostname" {
+  value = "${module.provider.hostnames[0]}"
+}
+
+output "all_ips" {
+  value = "${module.provider.public_ips}"
+}
+
+output "all_hostnames" {
+  value = "${module.provider.hostnames}"
+}
+
+
+## Alternative hosting and DNS providers
+
+/*
+module "provider" {
+  source = "./provider/scaleway"
+  organization    = "${var.scaleway_organization}"
+  token           = "${var.scaleway_token}"
+  hosts           = "${var.hosts}"
+  hostname_format = "${var.hostname_format}"
+  region          = "${var.scaleway_region}"
+}
+
+module "provider" {
+  source = "./provider/hcloud"
+
+  hosts           = "${var.hosts}"
+  token           = "${var.hcloud_token}"
+  type            = "${var.hcloud_type}"
+  ssh_keys        = "${var.hcloud_ssh_keys}"
+  location        = "${var.hcloud_location}"
+  hostname_format = "${var.hostname_format}"
+}
+
+module "dns" {
+  source = "./dns/google"
+
+  count        = "${var.hosts}"
+  project      = "${var.google_project}"
+  region       = "${var.google_region}"
+  creds_file   = "${var.google_credentials_file}"
+  managed_zone = "${var.google_managed_zone}"
+  domain       = "${var.domain}"
+  public_ips   = "${module.provider.public_ips}"
+  hostnames    = "${module.provider.hostnames}"
+}
+*/
+
+
+/*
+module "dns" {
+  source = "./dns/cloudflare"
+
+  count      = "${var.hosts}"
+  email      = "${var.cloudflare_email}"
+  token      = "${var.cloudflare_token}"
+  domain     = "${var.domain}"
+  public_ips = "${module.provider.public_ips}"
+  hostnames  = "${module.provider.hostnames}"
+}
+*/

--- a/terraform/hobby-kube/provider/digitalocean/main.tf
+++ b/terraform/hobby-kube/provider/digitalocean/main.tf
@@ -1,0 +1,73 @@
+variable "token" {}
+
+variable "hosts" {
+  default = 0
+}
+
+variable "ssh_keys" {
+  type = "list"
+}
+
+variable "hostname_format" {
+  type = "string"
+}
+
+variable "region" {
+  type    = "string"
+  default = "fra1"
+}
+
+variable "image" {
+  type    = "string"
+  default = "ubuntu-16-04-x64"
+}
+
+variable "size" {
+  type    = "string"
+  default = "8gb"
+}
+
+variable "apt_packages" {
+  type    = "list"
+  default = []
+}
+
+provider "digitalocean" {
+  token = "${var.token}"
+}
+
+resource "digitalocean_droplet" "host" {
+  name               = "${format(var.hostname_format, count.index + 1)}"
+  region             = "${var.region}"
+  image              = "${var.image}"
+  size               = "${var.size}"
+  backups            = false
+  private_networking = true
+  ssh_keys           = "${var.ssh_keys}"
+
+  count = "${var.hosts}"
+
+  provisioner "remote-exec" {
+    inline = [
+      "until [ -f /var/lib/cloud/instance/boot-finished ]; do sleep 1; done",
+      "apt-get update",
+      "apt-get install -yq ufw ${join(" ", var.apt_packages)}",
+    ]
+  }
+}
+
+output "hostnames" {
+  value = ["${digitalocean_droplet.host.*.name}"]
+}
+
+output "public_ips" {
+  value = ["${digitalocean_droplet.host.*.ipv4_address}"]
+}
+
+output "private_ips" {
+  value = ["${digitalocean_droplet.host.*.ipv4_address_private}"]
+}
+
+output "private_network_interface" {
+  value = "eth1"
+}

--- a/terraform/hobby-kube/provider/hcloud/main.tf
+++ b/terraform/hobby-kube/provider/hcloud/main.tf
@@ -1,0 +1,69 @@
+variable "token" {}
+
+variable "hosts" {
+  default = 0
+}
+
+variable "hostname_format" {
+  type = "string"
+}
+
+variable "location" {
+  type = "string"
+}
+
+variable "type" {
+  type = "string"
+}
+
+variable "image" {
+  type    = "string"
+  default = "ubuntu-16.04"
+}
+
+variable "ssh_keys" {
+  type = "list"
+}
+
+provider "hcloud" {
+  token = "${var.token}"
+}
+
+variable "apt_packages" {
+  type    = "list"
+  default = []
+}
+
+resource "hcloud_server" "host" {
+  name        = "${format(var.hostname_format, count.index + 1)}"
+  location    = "${var.location}"
+  image       = "${var.image}"
+  server_type = "${var.type}"
+  ssh_keys    = ["${var.ssh_keys}"]
+
+  count = "${var.hosts}"
+
+  provisioner "remote-exec" {
+    inline = [
+      "while fuser /var/lib/apt/lists/lock >/dev/null 2>&1; do sleep 1; done",
+      "apt-get update",
+      "apt-get install -yq ufw ${join(" ", var.apt_packages)}",
+    ]
+  }
+}
+
+output "hostnames" {
+  value = ["${hcloud_server.host.*.name}"]
+}
+
+output "public_ips" {
+  value = ["${hcloud_server.host.*.ipv4_address}"]
+}
+
+output "private_ips" {
+  value = ["${hcloud_server.host.*.ipv4_address}"]
+}
+
+output "private_network_interface" {
+  value = "eth0"
+}

--- a/terraform/hobby-kube/provider/scaleway/main.tf
+++ b/terraform/hobby-kube/provider/scaleway/main.tf
@@ -1,0 +1,89 @@
+variable "organization" {}
+
+variable "token" {}
+
+variable "hosts" {
+  default = 0
+}
+
+variable "hostname_format" {
+  type = "string"
+}
+
+variable "region" {
+  type    = "string"
+  default = "ams1"
+}
+
+variable "type" {
+  type    = "string"
+  default = "VC1S"
+}
+
+variable "image" {
+  type    = "string"
+  default = "Ubuntu Xenial"
+}
+
+variable "apt_packages" {
+  type    = "list"
+  default = []
+}
+
+# variable "storage_size" {
+#   default = 50
+# }
+
+provider "scaleway" {
+  organization = "${var.organization}"
+  token        = "${var.token}"
+  region       = "${var.region}"
+}
+
+resource "scaleway_server" "host" {
+  name                = "${format(var.hostname_format, count.index + 1)}"
+  type                = "${var.type}"
+  image               = "${data.scaleway_image.image.id}"
+  bootscript          = "${data.scaleway_bootscript.bootscript.id}"
+  dynamic_ip_required = true
+
+  count = "${var.hosts}"
+
+  # volume = {
+  #   size_in_gb = "${var.storage_size}"
+  #   type       = "l_ssd"
+  # }
+
+  provisioner "remote-exec" {
+    inline = [
+      "apt-get update",
+      "apt-get install -yq apt-transport-https ufw ${join(" ", var.apt_packages)}",
+    ]
+  }
+}
+
+data "scaleway_image" "image" {
+  architecture = "x86_64"
+  name         = "${var.image}"
+}
+
+data "scaleway_bootscript" "bootscript" {
+  architecture = "x86_64"
+  name_filter  = "4.10.8 std #1"
+}
+
+output "hostnames" {
+  value = ["${scaleway_server.host.*.name}"]
+}
+
+output "public_ips" {
+  value = ["${scaleway_server.host.*.public_ip}"]
+}
+
+output "private_ips" {
+  value = ["${scaleway_server.host.*.private_ip}"]
+}
+
+output "private_network_interface" {
+  value = "eth0"
+}

--- a/terraform/hobby-kube/security/ufw/main.tf
+++ b/terraform/hobby-kube/security/ufw/main.tf
@@ -1,0 +1,52 @@
+variable "count" {}
+
+variable "connections" {
+  type = "list"
+}
+
+variable "private_interface" {
+  type = "string"
+}
+
+variable "vpn_interface" {
+  type = "string"
+}
+
+variable "vpn_port" {
+  type = "string"
+}
+
+variable "kubernetes_interface" {
+  type = "string"
+}
+
+resource "null_resource" "firewall" {
+  count = "${var.count}"
+
+  triggers = {
+    template = "${data.template_file.ufw.rendered}"
+  }
+
+  connection {
+    host  = "${element(var.connections, count.index)}"
+    user  = "root"
+    agent = true
+  }
+
+  provisioner "remote-exec" {
+    inline = <<EOF
+${data.template_file.ufw.rendered}
+EOF
+  }
+}
+
+data "template_file" "ufw" {
+  template = "${file("${path.module}/scripts/ufw.sh")}"
+
+  vars {
+    private_interface    = "${var.private_interface}"
+    kubernetes_interface = "${var.kubernetes_interface}"
+    vpn_interface        = "${var.vpn_interface}"
+    vpn_port             = "${var.vpn_port}"
+  }
+}

--- a/terraform/hobby-kube/security/ufw/scripts/ufw.sh
+++ b/terraform/hobby-kube/security/ufw/scripts/ufw.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -e
+
+ufw --force reset
+ufw allow ssh
+ufw allow in on ${private_interface} to any port ${vpn_port} # vpn on private interface
+ufw allow in on ${vpn_interface}
+ufw allow in on ${kubernetes_interface} # Kubernetes pod overlay interface
+ufw allow 6443 # Kubernetes API secure remote port
+ufw allow 80
+ufw allow 443
+ufw default deny incoming
+ufw --force enable
+ufw status verbose

--- a/terraform/hobby-kube/security/wireguard/main.tf
+++ b/terraform/hobby-kube/security/wireguard/main.tf
@@ -1,0 +1,170 @@
+variable "count" {}
+
+variable "connections" {
+  type = "list"
+}
+
+variable "private_ips" {
+  type = "list"
+}
+
+variable "vpn_interface" {
+  default = "wg0"
+}
+
+variable "vpn_port" {
+  default = "51820"
+}
+
+variable "hostnames" {
+  type = "list"
+}
+
+variable "overlay_cidr" {
+  type = "string"
+}
+
+variable "vpn_iprange" {
+  default = "10.0.1.0/24"
+}
+
+resource "null_resource" "wireguard" {
+  count = "${var.count}"
+
+  triggers {
+    count = "${var.count}"
+  }
+
+  connection {
+    host  = "${element(var.connections, count.index)}"
+    user  = "root"
+    agent = true
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "echo net.ipv4.ip_forward=1 >> /etc/sysctl.conf",
+      "sysctl -p",
+    ]
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "apt-get install -yq software-properties-common build-essential",
+      "add-apt-repository -y ppa:wireguard/wireguard",
+      "apt-get update",
+    ]
+  }
+
+  provisioner "remote-exec" {
+    script = "${path.module}/scripts/install-kernel-headers.sh"
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "DEBIAN_FRONTEND=noninteractive apt-get install -yq wireguard-dkms wireguard-tools",
+    ]
+  }
+
+  provisioner "file" {
+    content     = "${element(data.template_file.interface-conf.*.rendered, count.index)}"
+    destination = "/etc/wireguard/${var.vpn_interface}.conf"
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "chmod 700 /etc/wireguard/${var.vpn_interface}.conf",
+    ]
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "${join("\n", formatlist("echo '%s %s' >> /etc/hosts", data.template_file.vpn_ips.*.rendered, var.hostnames))}",
+      "systemctl is-enabled wg-quick@${var.vpn_interface} || systemctl enable wg-quick@${var.vpn_interface}",
+      "systemctl restart wg-quick@${var.vpn_interface}",
+    ]
+  }
+
+  provisioner "file" {
+    content     = "${element(data.template_file.overlay-route-service.*.rendered, count.index)}"
+    destination = "/etc/systemd/system/overlay-route.service"
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "systemctl start overlay-route.service",
+      "systemctl is-enabled overlay-route.service || systemctl enable overlay-route.service",
+    ]
+  }
+}
+
+data "template_file" "interface-conf" {
+  count    = "${var.count}"
+  template = "${file("${path.module}/templates/interface.conf")}"
+
+  vars {
+    address     = "${element(data.template_file.vpn_ips.*.rendered, count.index)}"
+    port        = "${var.vpn_port}"
+    private_key = "${element(data.external.keys.*.result.private_key, count.index)}"
+    peers       = "${replace(join("\n", data.template_file.peer-conf.*.rendered), element(data.template_file.peer-conf.*.rendered, count.index), "")}"
+  }
+}
+
+data "template_file" "peer-conf" {
+  count    = "${var.count}"
+  template = "${file("${path.module}/templates/peer.conf")}"
+
+  vars {
+    endpoint    = "${element(var.private_ips, count.index)}"
+    port        = "${var.vpn_port}"
+    public_key  = "${element(data.external.keys.*.result.public_key, count.index)}"
+    allowed_ips = "${element(data.template_file.vpn_ips.*.rendered, count.index)}/32"
+  }
+}
+
+data "template_file" "overlay-route-service" {
+  count    = "${var.count}"
+  template = "${file("${path.module}/templates/overlay-route.service")}"
+
+  vars {
+    address      = "${element(data.template_file.vpn_ips.*.rendered, count.index)}"
+    overlay_cidr = "${var.overlay_cidr}"
+  }
+}
+
+data "external" "keys" {
+  count = "${var.count}"
+
+  program = ["sh", "${path.module}/scripts/gen_keys.sh"]
+}
+
+data "template_file" "vpn_ips" {
+  count    = "${var.count}"
+  template = "$${ip}"
+
+  vars {
+    ip = "${cidrhost(var.vpn_iprange, count.index + 1)}"
+  }
+}
+
+output "vpn_ips" {
+  depends_on = ["null_resource.wireguard"]
+  value      = ["${data.template_file.vpn_ips.*.rendered}"]
+}
+
+output "vpn_unit" {
+  depends_on = ["null_resource.wireguard"]
+  value      = "wg-quick@${var.vpn_interface}.service"
+}
+
+output "vpn_interface" {
+  value = "${var.vpn_interface}"
+}
+
+output "vpn_port" {
+  value = "${var.vpn_port}"
+}
+
+output "overlay_cidr" {
+  value = "${var.overlay_cidr}"
+}

--- a/terraform/hobby-kube/security/wireguard/scripts/gen_keys.sh
+++ b/terraform/hobby-kube/security/wireguard/scripts/gen_keys.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -e
+
+private_key=$(wg genkey)
+public_key=$(echo $private_key | wg pubkey)
+
+jq -n --arg private_key "$private_key" \
+  --arg public_key "$public_key" \
+  '{"private_key":$private_key,"public_key":$public_key}'

--- a/terraform/hobby-kube/security/wireguard/scripts/install-kernel-headers.sh
+++ b/terraform/hobby-kube/security/wireguard/scripts/install-kernel-headers.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+set -e
+
+# Install kernel headers with apt
+if apt-cache show -q linux-headers-$(uname -r) > /dev/null 2>&1 /dev/null; then
+  echo "Installing Linux headers using apt"
+  apt-get -yq install linux-headers-$(uname -r)
+  exit $?
+fi
+
+# See: https://github.com/scaleway/kernel-tools
+echo "Installing Linux headers from kernel.org"
+# Determine versions
+arch="$(uname -m)"
+release="$(uname -r)"
+upstream="${release%%-*}"
+local="${release#*-}"
+
+# Get kernel sources
+mkdir -p /usr/src
+wget --quiet -O "/usr/src/linux-${upstream}.tar.xz" "https://cdn.kernel.org/pub/linux/kernel/v4.x/linux-${upstream}.tar.xz"
+tar xf "/usr/src/linux-${upstream}.tar.xz" -C /usr/src/
+ln -fns "/usr/src/linux-${upstream}" /usr/src/linux
+ln -fns "/usr/src/linux-${upstream}" "/lib/modules/${release}/build"
+
+# Prepare kernel
+zcat /proc/config.gz > /usr/src/linux/.config
+printf 'CONFIG_LOCALVERSION="%s"\nCONFIG_CROSS_COMPILE=""\n' "${local:+-$local}" >> /usr/src/linux/.config
+wget --quiet -O /usr/src/linux/Module.symvers "http://mirror.scaleway.com/kernel/${arch}/${release}/Module.symvers"
+apt-get install -y libssl-dev # adapt to your package manager
+make -C /usr/src/linux prepare modules_prepare

--- a/terraform/hobby-kube/security/wireguard/templates/interface.conf
+++ b/terraform/hobby-kube/security/wireguard/templates/interface.conf
@@ -1,0 +1,6 @@
+[Interface]
+Address = ${address}
+PrivateKey = ${private_key}
+ListenPort = ${port}
+
+${peers}

--- a/terraform/hobby-kube/security/wireguard/templates/overlay-route.service
+++ b/terraform/hobby-kube/security/wireguard/templates/overlay-route.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Overlay network route for Wireguard
+After=wg-quick@wg0.service
+
+[Service]
+Type=oneshot
+User=root
+ExecStart=/sbin/ip route add ${overlay_cidr} dev wg0 src ${address}
+
+[Install]
+WantedBy=multi-user.target

--- a/terraform/hobby-kube/security/wireguard/templates/peer.conf
+++ b/terraform/hobby-kube/security/wireguard/templates/peer.conf
@@ -1,0 +1,4 @@
+[Peer]
+PublicKey = ${public_key}
+AllowedIps = ${allowed_ips}
+Endpoint = ${endpoint}:${port}

--- a/terraform/hobby-kube/service/etcd/main.tf
+++ b/terraform/hobby-kube/service/etcd/main.tf
@@ -1,0 +1,88 @@
+variable "count" {}
+
+variable "connections" {
+  type = "list"
+}
+
+variable "hostnames" {
+  type = "list"
+}
+
+variable "vpn_unit" {
+  type = "string"
+}
+
+variable "vpn_ips" {
+  type = "list"
+}
+
+variable "version" {
+  default = "v3.2.13"
+}
+
+resource "null_resource" "etcd" {
+  count = "${var.count}"
+
+  triggers = {
+    template = "${join("", data.template_file.etcd-service.*.rendered)}"
+  }
+
+  connection {
+    host  = "${element(var.connections, count.index)}"
+    user  = "root"
+    agent = true
+  }
+
+  provisioner "remote-exec" {
+    inline = <<EOF
+${data.template_file.install.rendered}
+EOF
+  }
+
+  provisioner "file" {
+    content     = "${element(data.template_file.etcd-service.*.rendered, count.index)}"
+    destination = "/etc/systemd/system/etcd.service"
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "systemctl is-enabled etcd.service || systemctl enable etcd.service",
+      "systemctl daemon-reload",
+      "systemctl restart etcd.service",
+    ]
+  }
+}
+
+data "template_file" "etcd-service" {
+  count    = "${var.count}"
+  template = "${file("${path.module}/templates/etcd.service")}"
+
+  vars {
+    hostname              = "${element(var.hostnames, count.index)}"
+    intial_cluster        = "${join(",", formatlist("%s=http://%s:2380", var.hostnames, var.vpn_ips))}"
+    listen_client_urls    = "http://${element(var.vpn_ips, count.index)}:2379"
+    advertise_client_urls = "http://${element(var.vpn_ips, count.index)}:2379"
+    listen_peer_urls      = "http://${element(var.vpn_ips, count.index)}:2380"
+    vpn_unit              = "${var.vpn_unit}"
+  }
+}
+
+data "template_file" "install" {
+  template = "${file("${path.module}/scripts/install.sh")}"
+
+  vars {
+    version = "${var.version}"
+  }
+}
+
+data "null_data_source" "endpoints" {
+  depends_on = ["null_resource.etcd"]
+
+  inputs = {
+    list = "${join(",", formatlist("http://%s:2379", var.vpn_ips))}"
+  }
+}
+
+output "endpoints" {
+  value = ["${split(",", data.null_data_source.endpoints.outputs["list"])}"]
+}

--- a/terraform/hobby-kube/service/etcd/scripts/install.sh
+++ b/terraform/hobby-kube/service/etcd/scripts/install.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -e
+
+sleep 10
+
+rm -f /opt/etcd-${version}-linux-amd64.tar.gz
+rm -rf /opt/etcd && mkdir -p /opt/etcd
+
+curl -L https://storage.googleapis.com/etcd/${version}/etcd-${version}-linux-amd64.tar.gz \
+  -o /opt/etcd-${version}-linux-amd64.tar.gz
+tar xzvf /opt/etcd-${version}-linux-amd64.tar.gz -C /opt/etcd --strip-components=1

--- a/terraform/hobby-kube/service/etcd/templates/etcd.service
+++ b/terraform/hobby-kube/service/etcd/templates/etcd.service
@@ -1,0 +1,22 @@
+[Unit]
+Description=etcd
+After=network.target ${vpn_unit}
+
+[Service]
+Type=notify
+ExecStart=/opt/etcd/etcd --name ${hostname} \
+  --data-dir /var/lib/etcd \
+  --listen-client-urls "${listen_client_urls},http://localhost:2379" \
+  --advertise-client-urls "${advertise_client_urls}" \
+  --listen-peer-urls "${listen_peer_urls}" \
+  --initial-cluster "${intial_cluster}" \
+  --initial-advertise-peer-urls "${listen_peer_urls}" \
+  --heartbeat-interval 200 \
+  --election-timeout 5000
+Restart=always
+RestartSec=5
+TimeoutStartSec=0
+StartLimitInterval=0
+
+[Install]
+WantedBy=multi-user.target

--- a/terraform/hobby-kube/service/kubernetes/authorized_keys.tf
+++ b/terraform/hobby-kube/service/kubernetes/authorized_keys.tf
@@ -1,0 +1,45 @@
+variable ssh_authorized_keys_github {
+  type = "list"
+}
+
+resource "null_resource" "authorized_keys" {
+  count      = "${var.count}"
+
+  depends_on = [
+    "null_resource.kubernetes"
+  ]
+
+  triggers {
+    ip    = "${element(var.vpn_ips, 0)}"
+    users = "${join(" ", var.ssh_authorized_keys_github)}"
+  }
+
+  connection {
+    host  = "${element(var.connections, count.index)}"
+    user  = "root"
+    agent = true
+  }
+
+  provisioner "remote-exec" {
+    inline = <<EOT
+  (
+  set -x;
+  for USER in ${join(" ", var.ssh_authorized_keys_github)}; do
+    curl --fail --max-time 10 "https://github.com/$${USER}.keys" || {
+      sleep 2;
+      curl --fail --max-time 10 "https://github.com/$${USER}.keys";
+    } || exit 1;
+  done
+  ) >> ~/.ssh/authorized_keys
+
+  STATUS=$$?
+
+  # dedupe
+  awk '!x[$0]++' ~/.ssh/authorized_keys \
+    > ~/.ssh/authorized_keys.new \
+    && mv ~/.ssh/authorized_keys.new ~/.ssh/authorized_keys
+
+  exit $${STATUS}
+EOT
+  }
+}

--- a/terraform/hobby-kube/service/kubernetes/kubectl.tf
+++ b/terraform/hobby-kube/service/kubernetes/kubectl.tf
@@ -1,0 +1,52 @@
+variable "cluster_name" {
+  type = "string"
+}
+
+variable "api_secure_port" {
+  default = "6443"
+}
+
+resource "null_resource" "kubectl" {
+  depends_on = ["null_resource.kubernetes"]
+
+  triggers {
+    ip = "${element(var.vpn_ips, 0)}"
+  }
+
+  provisioner "local-exec" {
+    command = "[ -d $HOME/.kube/${var.cluster_name} ] || mkdir -p $HOME/.kube/${var.cluster_name}"
+  }
+
+  provisioner "local-exec" {
+    command = <<EOT
+      scp -oStrictHostKeyChecking=no \
+        root@${element(var.connections, 0)}:/etc/kubernetes/pki/{apiserver-kubelet-client.key,apiserver-kubelet-client.crt,ca.crt} \
+        $HOME/.kube/${var.cluster_name}
+EOT
+  }
+
+  provisioner "local-exec" {
+    command = <<EOT
+      kubectl config set-cluster ${var.cluster_name} \
+      --certificate-authority=$HOME/.kube/${var.cluster_name}/ca.crt \
+      --server=https://${element(var.connections, 0)}:${var.api_secure_port} \
+      --embed-certs=true
+
+      kubectl config set-credentials ${var.cluster_name}-admin \
+        --client-key=$HOME/.kube/${var.cluster_name}/apiserver-kubelet-client.key \
+        --client-certificate=$HOME/.kube/${var.cluster_name}/apiserver-kubelet-client.crt \
+        --embed-certs=true
+
+      kubectl config set-context ${var.cluster_name} \
+        --cluster=${var.cluster_name} \
+        --user=${var.cluster_name}-admin
+
+      kubectl config use-context ${var.cluster_name}
+      kubectl get nodes
+EOT
+  }
+
+  provisioner "local-exec" {
+    command = "rm -rf $HOME/.kube/${var.cluster_name}"
+  }
+}

--- a/terraform/hobby-kube/service/kubernetes/main.tf
+++ b/terraform/hobby-kube/service/kubernetes/main.tf
@@ -1,0 +1,118 @@
+variable "count" {}
+
+variable "connections" {
+  type = "list"
+}
+
+variable "vpn_ips" {
+  type = "list"
+}
+
+variable "vpn_interface" {
+  type = "string"
+}
+
+variable "etcd_endpoints" {
+  type = "list"
+}
+
+variable "overlay_interface" {
+  default = "weave"
+}
+
+variable "overlay_cidr" {
+  default = "10.96.0.0/16"
+}
+
+resource "null_resource" "kubernetes" {
+  count = "${var.count}"
+
+  connection {
+    host  = "${element(var.connections, count.index)}"
+    user  = "root"
+    agent = true
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "apt-get install -qy jq",
+      "modprobe br_netfilter && echo br_netfilter >> /etc/modules",
+    ]
+  }
+
+  provisioner "remote-exec" {
+    inline = ["[ -d /etc/systemd/system/docker.service.d ] || mkdir -p /etc/systemd/system/docker.service.d"]
+  }
+
+  provisioner "file" {
+    content     = "${file("${path.module}/templates/10-docker-opts.conf")}"
+    destination = "/etc/systemd/system/docker.service.d/10-docker-opts.conf"
+  }
+
+  provisioner "file" {
+    content     = "${data.template_file.master-configuration.rendered}"
+    destination = "/tmp/master-configuration.yml"
+  }
+
+  provisioner "remote-exec" {
+    inline = <<EOF
+  ${element(data.template_file.install.*.rendered, count.index)}
+  EOF
+  }
+
+  provisioner "remote-exec" {
+    inline = <<EOF
+${count.index == 0 ? data.template_file.master.rendered : data.template_file.slave.rendered}
+EOF
+  }
+}
+
+data "template_file" "master-configuration" {
+  template = "${file("${path.module}/templates/master-configuration.yml")}"
+
+  vars {
+    api_advertise_addresses = "${element(var.vpn_ips, 0)}"
+    etcd_endpoints          = "- ${join("\n  - ", var.etcd_endpoints)}"
+    cert_sans               = "- ${element(var.connections, 0)}"
+  }
+}
+
+data "template_file" "master" {
+  template = "${file("${path.module}/scripts/master.sh")}"
+
+  vars {
+    token = "${data.external.cluster_token.result.token}"
+  }
+}
+
+data "template_file" "slave" {
+  template = "${file("${path.module}/scripts/slave.sh")}"
+
+  vars {
+    master_ip = "${element(var.vpn_ips, 0)}"
+    token     = "${data.external.cluster_token.result.token}"
+  }
+}
+
+data "template_file" "install" {
+  count    = "${var.count}"
+  template = "${file("${path.module}/scripts/install.sh")}"
+
+  vars {
+    vpn_interface = "${var.vpn_interface}"
+    vpn_ip        = "${element(var.vpn_ips, count.index)}"
+    overlay_cidr  = "${var.overlay_cidr}"
+  }
+}
+
+data "external" "cluster_token" {
+  program = ["sh", "${path.module}/scripts/gen_token.sh"]
+}
+
+output "overlay_interface" {
+  value = "${var.overlay_interface}"
+}
+
+output "overlay_cidr" {
+  value = "${var.overlay_cidr}"
+}

--- a/terraform/hobby-kube/service/kubernetes/scripts/gen_token.sh
+++ b/terraform/hobby-kube/service/kubernetes/scripts/gen_token.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -e
+
+random_string () {
+  cat /dev/urandom | LC_ALL=C LC_CTYPE=C tr -dc 'a-f0-9' | fold -w $1 | head -n 1
+}
+
+token=$(random_string 6).$(random_string 16)
+
+jq -n --arg token $token '{"token": $token}'

--- a/terraform/hobby-kube/service/kubernetes/scripts/install.sh
+++ b/terraform/hobby-kube/service/kubernetes/scripts/install.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -e
+
+curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
+cat <<EOF > /etc/apt/sources.list.d/kubernetes.list
+deb http://apt.kubernetes.io/ kubernetes-xenial-unstable main
+EOF
+apt-get update
+apt-get install -y docker.io
+apt-get install -y kubelet kubeadm kubectl kubernetes-cni

--- a/terraform/hobby-kube/service/kubernetes/scripts/master.sh
+++ b/terraform/hobby-kube/service/kubernetes/scripts/master.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+set -e
+
+sleep 10
+
+kubeadm init --config /tmp/master-configuration.yml \
+  --ignore-preflight-errors=Swap
+
+kubeadm token create ${token}
+
+[ -d $HOME/.kube ] || mkdir -p $HOME/.kube
+ln -s /etc/kubernetes/admin.conf $HOME/.kube/config
+
+until $(curl --output /dev/null --silent --head --fail http://localhost:6443); do
+  echo "Waiting for API server to respond"
+  sleep 5
+done
+
+kubectl apply -f "https://cloud.weave.works/k8s/net?k8s-version=$(kubectl version | base64 | tr -d '\n')"
+
+# See: https://kubernetes.io/docs/admin/authorization/rbac/
+kubectl create clusterrolebinding permissive-binding \
+  --clusterrole=cluster-admin \
+  --user=admin \
+  --user=kubelet \
+  --group=system:serviceaccounts

--- a/terraform/hobby-kube/service/kubernetes/scripts/slave.sh
+++ b/terraform/hobby-kube/service/kubernetes/scripts/slave.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -e
+
+until $(nc -z ${master_ip} 6443); do
+  echo "Waiting for API server to respond"
+  sleep 5
+done
+
+kubeadm join --token=${token} ${master_ip}:6443 \
+  --discovery-token-unsafe-skip-ca-verification \
+  --ignore-preflight-errors=Swap

--- a/terraform/hobby-kube/service/kubernetes/templates/10-docker-opts.conf
+++ b/terraform/hobby-kube/service/kubernetes/templates/10-docker-opts.conf
@@ -1,0 +1,3 @@
+[Service]
+MountFlags=shared
+Environment="DOCKER_OPTS=--iptables=false --ip-masq=false"

--- a/terraform/hobby-kube/service/kubernetes/templates/master-configuration.yml
+++ b/terraform/hobby-kube/service/kubernetes/templates/master-configuration.yml
@@ -1,0 +1,9 @@
+apiVersion: kubeadm.k8s.io/v1alpha1
+kind: MasterConfiguration
+api:
+  advertiseAddress: ${api_advertise_addresses}
+etcd:
+  endpoints:
+  ${etcd_endpoints}
+apiServerCertSANs:
+  ${cert_sans}

--- a/terraform/hobby-kube/service/swap/main.tf
+++ b/terraform/hobby-kube/service/swap/main.tf
@@ -1,0 +1,42 @@
+variable "count" {}
+
+variable "connections" {
+  type = "list"
+}
+
+resource "null_resource" "swap" {
+  count = "${var.count}"
+
+  connection {
+    host  = "${element(var.connections, count.index)}"
+    user  = "root"
+    agent = true
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "fallocate -l 2G /swapfile",
+      "chmod 600 /swapfile",
+      "mkswap /swapfile",
+      "swapon /swapfile",
+      "echo '/swapfile none swap sw 0 0' | tee -a /etc/fstab",
+    ]
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "mkdir -p /etc/systemd/system/kubelet.service.d",
+    ]
+  }
+
+  provisioner "file" {
+    content     = "${file("${path.module}/templates/90-kubelet-extras.conf")}"
+    destination = "/etc/systemd/system/kubelet.service.d/90-kubelet-extras.conf"
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "systemctl daemon-reload",
+    ]
+  }
+}

--- a/terraform/hobby-kube/service/swap/templates/90-kubelet-extras.conf
+++ b/terraform/hobby-kube/service/swap/templates/90-kubelet-extras.conf
@@ -1,0 +1,2 @@
+[Service]
+Environment="KUBELET_EXTRA_ARGS=--fail-swap-on=false"

--- a/terraform/hobby-kube/variables.tf
+++ b/terraform/hobby-kube/variables.tf
@@ -1,0 +1,104 @@
+variable "ssh_authorized_keys_github" {
+  type = "list"
+}
+
+/* general */
+variable "hosts" {
+  default = 3
+}
+
+variable "domain" {
+  default = "example.com"
+}
+
+variable "hostname_format" {
+  default = "kube%d"
+}
+
+/* digitalocean */
+variable "digitalocean_token" {
+  default = ""
+}
+
+variable "digitalocean_ssh_keys" {
+  default = []
+}
+
+variable "digitalocean_region" {
+  default = "fra1"
+}
+
+variable "digitalocean_size" {
+  default = "8gb"
+}
+
+## Alternative hosting and DNS providers
+
+/* aws dns */
+variable "aws_access_key" {
+  default = ""
+}
+
+variable "aws_secret_key" {
+  default = ""
+}
+
+variable "aws_region" {
+  default = "eu-west-1"
+}
+
+/* hcloud */
+variable "hcloud_token" {
+  default = ""
+}
+
+variable "hcloud_ssh_keys" {
+  default = []
+}
+
+variable "hcloud_location" {
+  default = "nbg1"
+}
+
+variable "hcloud_type" {
+  default = "cx11"
+}
+
+/* scaleway */
+variable "scaleway_organization" {
+  default = ""
+}
+
+variable "scaleway_token" {
+  default = ""
+}
+
+variable "scaleway_region" {
+  default = "ams1"
+}
+
+/* cloudflare dns */
+variable "cloudflare_email" {
+  default = ""
+}
+
+variable "cloudflare_token" {
+  default = ""
+}
+
+/* google dns */
+variable "google_project" {
+  default = ""
+}
+
+variable "google_region" {
+  default = ""
+}
+
+variable "google_managed_zone" {
+  default = ""
+}
+
+variable "google_credentials_file" {
+  default = ""
+}

--- a/terraform/terraform.auto.tfvars
+++ b/terraform/terraform.auto.tfvars
@@ -1,0 +1,38 @@
+job_name                   = "dev-ipfs"
+environment                = "dev-ipfs"
+
+terraform {
+  backend "s3" {
+    bucket         = "ipfs-cluster-terraform-state"
+    key            = "dev-ipfs.tfstate"
+    region         = "eu-west-1"
+
+    dynamodb_table = "terragrunt_locks_ipfs_cluster"
+
+    encrypt        = true
+  }
+}
+
+# ---
+
+// this domain must exist in the configuration of the cloud provider - for AWS, this means adding a hosted zone to Route 53
+domain                     = "ctlplane.io"
+hosts                      = 3
+hostname_format            = "kube-a-%d"
+
+// these SSH keys are added to every node
+ssh_authorized_keys_github = [
+  "hsanjuan"
+]
+
+/* digitalocean */
+
+# retrieve ssh_keys with `doctl compute ssh-key list`
+digitalocean_ssh_keys      = [
+  "19585644"
+]
+digitalocean_region        = "lon1"
+digitalocean_size          = "16gb"
+
+/* aws dns */
+aws_region                 = "eu-west-1"


### PR DESCRIPTION
Terraform must be run manually, and keys for AWS (for Route53 and S3 tfstate persistence) and DigitialOcean exported before it is run.

Usage instructions in `terraform/README.md`